### PR TITLE
Remove postfix syntax from ISA language specification

### DIFF
--- a/examples/bit-field.isa
+++ b/examples/bit-field.isa
@@ -3,7 +3,7 @@
 
 :insn size=32 subfields={
     #Valid bit fields
-    AA?a @(30) op=func descr="Absolute Address flag, bit 30"
+    AA @(30) op=func descr="Absolute Address flag, bit 30"
     BD @(16-29|0b00) op=imm descr="Displacement, bits 16-29, padded with 00b"
     SIMM @(?1|18-19|0b01) op=imm descr="Sign extended with 01b pad bits"
     rA @(11-15) op=insn;GPR descr="Register A, bits 11-15, is a GPR"

--- a/examples/unnamed-field.isa
+++ b/examples/unnamed-field.isa
@@ -6,7 +6,7 @@
 
 # This should work - unnamed field definition with space-scoped subfields
 :insn size=32 subfields={
-    AA?a @(30) op=func descr="Absolute Address flag, bit 30"
+    AA @(30) op=func descr="Absolute Address flag, bit 30"
     BD @(16-29|0b00) op=imm descr="Displacement, bits 16-29, padded with 00b"
     rA @(11-15) op=insn;GPR descr="Register A, bits 11-15, is a GPR"
     opc6 @(0-5) op=func descr="Primary 6-bit opcode field, bits 0-5"

--- a/examples/valid-file.isa
+++ b/examples/valid-file.isa
@@ -34,8 +34,8 @@ subfields={
     rD @(6-10) op=reg;GPR
 
     #example of a single character tag
-    OE?o @(21) op=func
-    Rc?. @(31) op=func
+    OE @(21) op=func
+    Rc @(31) op=func
 
     # A more complicated bit field definition
     pmrn @(?1||16-20||11-15||0b00)

--- a/spec/isa_language_specification.md
+++ b/spec/isa_language_specification.md
@@ -73,7 +73,7 @@ Bit specifications are used in field definitions and instruction definitions. Th
 
 **Single Bit**:
 - `@(<bit_index>)`: A single bit.
-- Example: `AA?a @(30)` refers to bit 30.
+- Example: `AA @(30)` refers to bit 30.
 
 **Bit Range**:
 - `@(<start_bit>-<end_bit>)`: A contiguous range of bits, inclusive. `start_bit` is typically the more significant bit index.
@@ -279,11 +279,10 @@ Subfields defined in untagged fields do not have a memory space and can be refer
 
 Each subfield definition shall occur within a `subfields={}` option tag context window. Only one subfield definition shall be on a line and following the following format:
 
-**Syntax**: `<subfield_tag>[?<postfix>] @(<bit_spec>)[|<bit_spec>...] [op=<type>[.<subtype>][|<type>...]] [descr="<description>"]`
+**Syntax**: `<subfield_tag> @(<bit_spec>)[|<bit_spec>...] [op=<type>[.<subtype>][|<type>...]] [descr="<description>"]`
 
 **Subfield Components**:
 - **REQUIRED** `<subfield_tag>`: Unique name for the subfield (e.g., `AA`, `BD`, `rA`). `subfield_tag` shall be highlighted/colored the same as the encompassing `space_tag`.
-- **OPTIONAL** `?<postfix>`: Optional single-character postfix (e.g., `?a`, `?l`). If present, `op` often includes `func`. This postfix can be appended to the `field_name` or `instruction_name` during disassembly (e.g., `b` + `LK?l` -> `bl`) if bit is set. Anything with a postfix needs to be a single bit.  The postfix portion including the ? is not part of the `<subfield_tag>`.
 - **REQUIRED** `@(<bit_field>)`: Bit specification for the field within a field (see "Bit Specification Details" in Section 8).
   - Example: `DCRN @(16-20|11-15)` means bits 16-20 are concatenated with bits 11-15 to form the `DCRN` field.
 - **OPTIONAL** `op=<type>[.<subtype>][|<type>...]`: Defines the operational type and properties of the field. Multiple types can be OR'd using `|`.
@@ -334,14 +333,14 @@ Each subfield definition shall occur within a `subfields={}` option tag context 
 
 # Untagged subfield definitions for instructions
 :insn subfields={
-    AA?a @(30) op=func descr="Absolute Address flag, bit 30"
+    AA @(30) op=func descr="Absolute Address flag, bit 30"
     BD @(16-29|0b00) op=imm descr="Displacement, bits 16-29, padded with 00b"
     rA @(11-15) op=reg.GPR descr="Register A, bits 11-15, is a GPR"
     opc6 @(0-5) op=func descr="Primary 6-bit opcode field, bits 0-5"
 }
 
 :insn size=16 subfields={
-    AA16?a @(14) op=func # inline comment
+    AA16 @(14) op=func # inline comment
     # error_bitidx @(20) # should provide error because maximum bit index is 15 in this space
 }
 ```
@@ -376,8 +375,8 @@ Defines individual machine instructions, their mnemonics, operand fields, and ma
     rD @(6-10) op=target|reg.GPR
     rA @(11-15) op=source|reg.GPR
     rB @(16-20) op=source|reg.GPR
-    OE?o @(21) op=func
-    Rc?. @(31) op=func
+    OE @(21) op=func
+    Rc @(31) op=func
 }
 
 :insn add (rD,rA,rB) mask={opc6=0b011111 OE=0 @(22-30)=0b100001010 Rc=0} descr="Add"

--- a/spec/postfix_removed_addendum.md
+++ b/spec/postfix_removed_addendum.md
@@ -1,0 +1,61 @@
+# Postfix Operation Removal Addendum
+
+## Summary
+This addendum removes the postfix operation syntax (`?<postfix>`) from the ISA language specification. This change simplifies the subfield definition syntax and removes the complex postfix handling logic from instruction disassembly.
+
+## Changes to Section 9.1.2 Subfields
+
+### Original Subfield Syntax (REMOVED)
+```
+<subfield_tag>[?<postfix>] @(<bit_spec>)[|<bit_spec>...] [op=<type>[.<subtype>][|<type>...]] [descr="<description>"]
+```
+
+### New Subfield Syntax
+```
+<subfield_tag> @(<bit_spec>)[|<bit_spec>...] [op=<type>[.<subtype>][|<type>...]] [descr="<description>"]
+```
+
+## Removed Components
+
+### Postfix Syntax
+- **REMOVED** `?<postfix>`: Optional single-character postfix (e.g., `?a`, `?l`) is no longer supported
+- **REMOVED** Postfix appending to field_name or instruction_name during disassembly
+- **REMOVED** Single-bit requirement for postfix fields
+
+## Impact on Existing Examples
+
+### Before (with postfix)
+```plaintext
+:insn subfields={
+    AA?a @(30) op=func descr="Absolute Address flag, bit 30"
+    LK?l @(31) op=func descr="Link flag, bit 31"
+    OE?o @(21) op=func descr="Overflow Enable flag, bit 21"
+    Rc?. @(31) op=func descr="Record flag, bit 31"
+}
+```
+
+### After (without postfix)
+```plaintext
+:insn subfields={
+    AA @(30) op=func descr="Absolute Address flag, bit 30"
+    LK @(31) op=func descr="Link flag, bit 31"
+    OE @(21) op=func descr="Overflow Enable flag, bit 21"
+    Rc @(31) op=func descr="Record flag, bit 31"
+}
+```
+
+## Migration Guide
+
+1. **Remove postfix characters**: Remove the `?<character>` portion from all subfield definitions
+2. **Update field names**: If the postfix character was meaningful, incorporate it into the base `<subfield_tag>` name
+3. **Update disassembly logic**: Any code that relied on postfix-based instruction name modification must be updated to handle field-based logic instead
+
+## Rationale
+
+- **Simplification**: Removes complex postfix handling logic from parsers and disassemblers
+- **Clarity**: Subfield names are now explicit rather than having dynamic postfix behavior
+- **Consistency**: Eliminates special-case handling for single-bit postfix fields
+- **Maintainability**: Reduces parser complexity and potential edge cases
+
+## Effective Date
+This change takes effect immediately upon adoption of this addendum. All new ISA files should follow the updated syntax without postfix operations.


### PR DESCRIPTION
## Summary
Implement the postfix removal addendum to simplify the ISA language specification by removing the `?<postfix>` syntax from subfield definitions.

## Changes Made
- Remove postfix syntax (`?a`, `?l`, `?o`, `?.`) from all example files:
  - `examples/bit-field.isa`
  - `examples/unnamed-field.isa` 
  - `examples/valid-file.isa`
- Update ISA language specification (`spec/isa_language_specification.md`):
  - Remove `[?<postfix>]` from subfield syntax definition
  - Remove postfix documentation from Section 9.1.2 Subfields
  - Update all syntax examples to use simplified format

## Test Plan
- [x] Verified all example files parse correctly after changes
- [x] Ran existing test suite to ensure no regression
- [x] Updated specification documentation matches implementation
- [x] Removed all references to postfix operations

🤖 Generated with [Claude Code](https://claude.ai/code)