### PR TITLE
Fix field parsing issues: mask content and alias/redirect

### DIFF
--- a/server/src/analysis/semantic-analyzer.ts
+++ b/server/src/analysis/semantic-analyzer.ts
@@ -718,7 +718,7 @@ export class SemanticAnalyzer {
           const isInstructionOperand = recentContent.includes('(') && recentContent.includes(')');
           if (fieldDirectivePattern.test(recentContent) && !isInstructionOperand && this.isInvalidFieldOption(token.text)) {
             errors.push({
-              message: `Invalid field option: '${token.text}'. Valid options are: offset, size, count, reset, name, descr, alias`,
+              message: `Invalid field option: '${token.text}'. Valid options are: offset, size, count, reset, name, descr, redirect`,
               location: this.ensureValidRange(token.location),
               severity: 'warning',
               code: 'invalid-field-option',
@@ -747,8 +747,10 @@ export class SemanticAnalyzer {
           }
           
           // Instruction option validation (for instruction definitions with options like mask=)
+          // Only validate instruction options outside of mask={} and other nested contexts
           const instructionPattern = /:(\w+)\s+\w+\s*\([^)]*\)\s/;
-          if (instructionPattern.test(recentContent) && this.isInvalidInstructionOption(token.text)) {
+          const inMaskContext = recentContent.includes('mask={') && !recentContent.includes('}');
+          if (instructionPattern.test(recentContent) && !inMaskContext && this.isInvalidInstructionOption(token.text)) {
             errors.push({
               message: `Invalid instruction option: '${token.text}'. Valid options are: mask, descr, semantics`,
               location: this.ensureValidRange(token.location),


### PR DESCRIPTION
## Summary
- Fixed incorrect parsing of field assignments within `mask={}` blocks as instruction options
- Updated field option validation error message to show 'redirect' instead of deprecated 'alias'
- Added proper context awareness to distinguish instruction-level options from mask field assignments

## Problem Fixed
The language server was incorrectly flagging field assignments like `opcd5=0b1111111` and `AA=0b5` inside `mask={...}` blocks as invalid instruction options, when they should be treated as valid field assignments within the mask context.

Additionally, the error message for invalid field options still referenced the old 'alias' option instead of the current 'redirect' option.

## Changes Made
1. **`semantic-analyzer.ts:721`**: Updated error message to use 'redirect' instead of 'alias'
2. **`semantic-analyzer.ts:752`**: Added mask context detection to prevent instruction option validation inside `mask={}` blocks

## Test Plan
- [x] Build completes without TypeScript errors
- [x] Existing tests continue to pass (some pre-existing test failures unrelated to these changes)
- [x] Field assignments within mask blocks no longer trigger invalid instruction option warnings
- [x] Field option validation now correctly shows 'redirect' instead of 'alias' in error messages

🤖 Generated with [Claude Code](https://claude.ai/code)